### PR TITLE
Fix v1.18 API docs formatting

### DIFF
--- a/docs/api-documentation/V1.18/index.md
+++ b/docs/api-documentation/V1.18/index.md
@@ -2757,65 +2757,48 @@ This section lists any significant changes made to this document (and by extensi
 Version 1.18 (19/03/2020):
 {: .govuk-heading-s}
 
-Workstream restrictions will be taking effect on the Work API. See the <a class="govuk-link" href="#access-and-permissions">access and permissions</a> section for further details.
-{: .govuk-body}
-
 Town will now be stored in Street Manager:
 {: .govuk-body}
 
+In the Works API, the following endpoints have been updated to include the optional property <code>town</code> in its request body (if not provided, it will be inferred from NSG data):
+{: .govuk-body}
+
 <ol class="govuk-list govuk-list--bullet">
+  <li><code>POST /activity</code></li>
+  <li><code>POST /forward-plans</code></li>
+  <li><code>POST /historic-works/fixed-penalty-notices</code></li>
+  <li><code>POST /historic-works/inspections</code></li>
+  <li><code>POST /non-notifiable-works/sites</code></li>
+  <li><code>POST /section-81-works/section-81s</code></li>
+  <li><code>POST /works</code></li>
+</ol>
 
-  In the Works API, the following endpoints have been updated to include the optional property <code>town</code> in its request body (if not provided, it will be inferred from NSG data):
-  {: .govuk-body}
+In the Works API, the following endpoints now include <code>town</code> in their respective responses:
+{: .govuk-body}
 
-  <li>
-    <ol class="govuk-list govuk-list--bullet">
-      <li><code>POST /activity</code></li>
-      <li><code>POST /forward-plans</code></li>
-      <li><code>POST /historic-works/fixed-penalty-notices</code></li>
-      <li><code>POST ​/historic-works​/inspections</code></li>
-      <li><code>POST ​/non-notifiable-works​/sites</code></li>
-      <li><code>POST /section-81-works/section-81s</code></li>
-      <li><code>POST /works</code></li>
-    </ol>
-  </li>
+<ol class="govuk-list govuk-list--bullet">
+  <li><code>GET /works/{workReferenceNumber}</code></li>
+  <li><code>GET /works/{workReferenceNumber}/forward-plans/{forwardPlanReferenceNumber}</code></li>
+  <li><code>GET /works/{workReferenceNumber}/permits/{permitReferenceNumber}</code></li>
+  <li><code>GET /works/{workReferenceNumber}/permits/{permitReferenceNumber}/alterations/{permitAlterationReferenceNumber}</code></li>
+  <li><code>GET /works/{workReferenceNumber}/section-81s/{section81ReferenceNumber}</code></li>
+</ol>
 
-  In the Works API, the following endpoints now include <code>town</code> in their respective responses:
-  {: .govuk-body}
+In the Reporting API, the following endpoints now include <code>town</code> in their respective responses:
+{: .govuk-body}
 
-  <li>
-    <ol class="govuk-list govuk-list--bullet">
-      <li><code>GET /works/{workReferenceNumber}</code></li>
-      <li><code>GET /works/{workReferenceNumber}/forward-plans/{forwardPlanReferenceNumber}</code></li>
-      <li><code>GET /works/{workReferenceNumber}/permits/{permitReferenceNumber}</code></li>
-      <li><code>GET /works/{workReferenceNumber}/permits/{permitReferenceNumber}/alterations/{permitAlterationReferenceNumber}</code></li>
-      <li><code>GET /works/{workReferenceNumber}/section-81s/{section81ReferenceNumber}</code></li>
-    </ol>
-  </li>
-
-  In the Reporting API, the following endpoints now include <code>town</code> in their respective responses:
-  {: .govuk-body}
-
-  <li>
-    <ol class="govuk-list govuk-list--bullet">
-      <li><code>GET /alterations</code></li>
-      <li><code>GET /forward-plans</code></li>
-      <li><code>GET /inspections</code></li>
-      <li><code>GET /permits</code></li>
-      <li><code>GET /reinstatements</code></li>
-      <li><code>GET /section-81s</code></li>
-    </ol>
-  </li>
+<ol class="govuk-list govuk-list--bullet">
+  <li><code>GET /alterations</code></li>
+  <li><code>GET /forward-plans</code></li>
+  <li><code>GET /inspections</code></li>
+  <li><code>GET /permits</code></li>
+  <li><code>GET /reinstatements</code></li>
+  <li><code>GET /section-81s</code></li>
 </ol>
 
 Updated Work API with the following changes:
 {: .govuk-body}
 <ol class="govuk-list govuk-list--bullet">
-  <li>Updated the `object_reference` of audits relating to the <code>event_type</code> of reinstatement_submitted. This will now return the site number that can be used as the resource identifier in <code>GET /works/{workReferenceNumber}/sites/{siteNumber}</code>. This change was applied to the <code>GET /works/{workReferenceNumber}</code> and <code>GET /works/{workReferenceNumber}/history</code> endpoints.</li>
-  <li>Planned permits no longer need to be granted by HA before works can be started</li>
-  <li>Planned permits can be assessed at any stage, provided they haven't been assessed or cancelled</li>
-  <li>Updated the <code>PUT /works/{workReferenceNumber}/permits/{permitReferenceNumber}/assessment</code> endpoint to now accept the additional values <code>reasonable_period_end_date</code> and <code>is_duration_challenged</code></li>
-  <li>The <code>PermitResponse</code> has been updated to return <code>is_duration_challenged</code></li>
   <li>Fixed a defect with the <code>DELETE /files/{fileId}</code> endpoint so it now correctly returns a precondition failed error if the file has already been associated with a work</li>
   <li>Fixed a defect with the <code>GET /works/{workReferenceNumber}/history</code> endpoint so it now correctly returns <code>inspection_agreed_site_compliance</code> AuditEvent enum where applicable instead of the event not being returned</li>
   <li>Users can now update the <code>works_coordinates</code> property when submitting a Permit Alteration to the <code>/works/{workReferenceNumber}/permits/{permitReferenceNumber}/alterations</code> endpoint.</li>
@@ -2827,6 +2810,7 @@ Updated Work API with the following changes:
       <li><code>PUT /works/{workReferenceNumber}/inspection-units</code></li>
     </ol>
   </li>
+
   <li>The following audit event types have been added, these are used when creating a work:
     <ol class="govuk-list govuk-list--bullet">
       <li><code>planned_works_record_created</code></li>
@@ -2836,33 +2820,8 @@ Updated Work API with the following changes:
       <li><code>section_81_works_record_created</code></li>
       <li><code>unattributable_works_record_created</code></li>
     </ol>
-  <li>
-</ol>
-
-Updated Party API with the following changes:
-{: .govuk-body}
-<ol class="govuk-list govuk-list--bullet">
-  <li>Updated the <code>GET /users/{email}</code> endpoint to accept <code>swaCode</code> query parameter. This can be used by contractors to see the workstreams they have available for a particular contract</li>
-</ol>
-
-The Data Export API has been updated with the following changes:
-{: .govuk-body}
-
-<ol class="govuk-list govuk-list--bullet">
-  <li><code>POST /permits/csv</code> has been updated with the following new properties:
-    <ol class="govuk-list govuk-list--bullet">
-      <li><code>geographical_area_reference_number</code></li>
-      <li><code>is_duration_challenged</code></li>
-    </ol>
   </li>
-  <li><code>POST /permits/csv</code>has been updated with the new <code>geographical_area_reference_number</code> property</li>
-  <li><code>POST /alterations/csv</code>has been updated with the new <code>geographical_area_reference_number</code> property</li>
-  <li><code>POST /forward-plans/csv</code>has been updated with the new <code>geographical_area_reference_number</code> property</li>
-  <li><code>POST /reinstatements/csv</code>has been updated with the new <code>geographical_area_reference_number</code> property</li>
-  <li><code>POST /section-81s/csv</code>has been updated with the new <code>geographical_area_reference_number</code> property</li>
-  <li><code>POST /inspections/csv</code>has been updated with the new <code>geographical_area_reference_number</code> property</li>
-  <li><code>POST /fixed-penalty-notices/csv</code>has been updated with the new <code>geographical_area_reference_number</code> property</li>
-  <li>Updated the <code>GET /work-data</code> endpoint to allow previously generated CSVs to be retrieved.</li>
+
   <li>Updated the <code>GET /work-data</code> endpoint so that it is now accessible to users with the following roles:
     <ol class="govuk-list govuk-list--bullet">
       <li><code>Planner</code></li>
@@ -2872,60 +2831,23 @@ The Data Export API has been updated with the following changes:
       <li><code>DataExport</code></li>
     </ol>
   </li>
-  <li>Updated the <code>GET /work-data</code> endpoint to include the following additional fields in generated CSVs:
-    <ol class="govuk-list govuk-list--bullet">
-      <li><code>Highway authority swa code</code></li>
-      <li><code>Works category reference</code></li>
-      <li><code>Traffic management type reference</code></li>
-      <li><code>Assessment status reference</code></li>
-      <li><code>Permit status reference</code></li>
-      <li><code>Work status reference</code></li>
-    </ol>
-  </li>
-  <li>New <code>GET /activity-data</code> endpoint added to retrieve data of activities across all organisations which have been added, changed, or deleted within the last hour in CSV format.</li>
-  <li>New <code>POST /comments/csv</code> endpoint added to trigger generation of Comment CSV file</li>
 </ol>
-
-Reporting API has been updated with the following changes:
-{: .govuk-body}
-
-<ol class="govuk-list govuk-list--bullet">
-  <li><code>GET works/updates</code> endpoint has been updated to return the <code>event_type</code> and <code>object_type</code> properties. Returns updates for new events, for more information, see
-  audit events in the documentation 'History' section.</li>
-  <li><code>GET /alterations</code> endpoint now accepts the following <code>sort_column</code> values: <code>date_created</code>, <code>proposed_start_date</code>, <code>proposed_end_date</code> and <code>status_changed_date</code></li>
-  <li><code>GET permits/csv</code> endpoint now accepts the additional value <code>is_duration_challenged</code></li>
-  <li>The following Reporting API endpoints have been updated with a new <code>geographical_area_reference_number</code> property that enables HA users to filter their lists based on one or more Geographical Areas within their organisation:
-  <ol class="govuk-list govuk-list--bullet">
-    <li><code>GET /permits</code></li>
-    <li><code>GET /alterations</code></li>
-    <li><code>GET /forward-plans</code></li>
-    <li><code>GET /reinstatements</code></li>
-    <li><code>GET /section-81s</code></li>
-    <li><code>GET /inspections</code></li>
-    <li><code>GET /comments</code></li>
-    <li><code>GET /fixed-penalty-notices</code></li>
-  </ol>
-  </li>
-</ol>
-
-
-Version 1.18 (19/03/2020):
-{: .govuk-heading-s}
 
 Updated Street Lookup API with the following changes:
 {: .govuk-body}
+
 <ol class="govuk-list govuk-list--bullet">
   <li>Property <code>road_category</code> marked as deprecated and will be removed from the response of the following endpoints in a future release: <code>GET /nsg/streets</code> and
   <code>GET /nsg/streets/{usrn}</code>.</li>
   <li>Property <code>reinstatement_types</code> added to the response of the following endpoints: <code>GET /nsg/streets</code> and <code>GET /nsg/streets/{usrn}</code>. This property contains a
   collection of reinstatement type codes and corresponding location text. For more information on the <code>reinstatement_type_code</code> property see the `Reinstatement type codes` section above.</li>
-  <li>The streets returned in the response of the following endpoints now include streets with reinstatement type code value of up to 10 and where the street state does not equal 4: <code>GET /nsg/streets</code> and <code>GET /nsg/streets/{usrn}</code>.
+  <li>The streets returned in the response of the following endpoints now include streets with reinstatement type code value of up to 10 and where the street state does not equal 4: <code>GET /nsg/streets</code> and <code>GET /nsg/streets/{usrn}</code>.</li>
 </ol>
 
 Updated Work API with the following changes:
 {: .govuk-body}
 <ol class="govuk-list govuk-list--bullet">
-  <li>All existing create endpoints which currently accept the property <code>road_category</code> have been updated to now accept a value of up to 10.
+  <li>All existing create endpoints which currently accept the property <code>road_category</code> have been updated to now accept a value of up to 10.</li>
 </ol>
 
 Version 1.17 (05/03/2020):


### PR DESCRIPTION
### Issues
- There was a mix of v1.17 in the v1.18 section.
- There was also some formatting issues meaning the gov styling tags were showing. See current versions section for example: https://departmentfortransport.github.io/street-manager-docs/api-documentation/V1.18/#versions
- Quickest way to fix the above issue was to remove indentation. FYI @peadarkelly the new town section is no longer indented.
---------
### Before
<img width="708" alt="Screen Shot 2020-03-18 at 15 58 23" src="https://user-images.githubusercontent.com/9826034/76982962-88a5bb00-6934-11ea-887a-4be4d708e81a.png">

---------

### After
<img width="707" alt="Screen Shot 2020-03-18 at 15 58 04" src="https://user-images.githubusercontent.com/9826034/76982994-978c6d80-6934-11ea-82cb-e024369fe899.png">
