### PR TITLE
Fix formatting of v1.20 API docs

### DIFF
--- a/docs/api-documentation/V1.20/index.md
+++ b/docs/api-documentation/V1.20/index.md
@@ -2784,7 +2784,7 @@ Updated Works API with the following changes:
       <li><code>upcoming_event</code> (placeholder for a future audit event)</li>
     </ol>
   </li>
-<ol>
+</ol>
 
 Version 1.19 (26/03/2020):
 {: .govuk-heading-s}


### PR DESCRIPTION
A list is missing a closing tag in the v1.20 API docs, affecting formatting for the bottom of the page.