### PR TITLE
Update api docs version info following v1.21 release

### DIFF
--- a/docs/api-documentation/index.html
+++ b/docs/api-documentation/index.html
@@ -51,13 +51,8 @@ This is the V1 baseline specification which describes all legally required API f
 <ul class="govuk-list govuk-list--bullet">
   <li>
     <!-- UPDATE ME TO latest CURRENT version -->
-    <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V1.20/">
-      Version 1.20 - Released to PRODUCTION (06/04/2020)
-    </a>
-  </li>
-  <li>
     <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V1.21/">
-      Version 1.21 - Released to SANDBOX (16/04/2020). Due for release to PRODUCTION 23/04/2020.
+      Version 1.21 - Released to SANDBOX (16/04/2020). Released to PRODUCTION (23/04/2020).
     </a>
   </li>
 </ul>
@@ -70,7 +65,7 @@ This is the V1 baseline specification which describes all legally required API f
 <ul class="govuk-list govuk-list--bullet">
   <li>
     <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V1.22/">
-      Version 1.22 - Due for release to SANDBOX 30/04/2020
+      Version 1.22 - Due for release to SANDBOX 30/04/2020. Due for release to PRODUCTION 07/05/2020.
     </a>
   </li>
 </ul>


### PR DESCRIPTION
- Removed v1.20 as the current production version
- Added v1.22 release date