### PR TITLE
feature/SM-3969: asd start and end dates

### DIFF
--- a/docs/api-documentation/V1.23/index.md
+++ b/docs/api-documentation/V1.23/index.md
@@ -2807,6 +2807,17 @@ Updated Works API with the following changes:
   <li>
     The definitions for <code>ASDCode</code> and <code>ASDPeriodicityCode</code> models have been updated to clarify that the enum values should be submitted as numbers instead of strings. <strong>Note that, in a future release, we will be adding validation against providing strings.</strong> The API will continue to accept both for the time being, but we strongly encourage submitting these values as numbers instead of strings if you aren't already doing so.
   </li>
+  <li>
+    <code>PermitASD</code> interface, which is used in a number of work and permit request and response models, will be updated to include new optional date properties <code>special_desig_start_date</code> and <code>special_desig_end_date</code>. These fields will be stored against the work and returned on the appropriate responses where avilable. Affected models include:
+    <ol class="govuk-list govuk-list--bullet">
+      <li><code>ForwardPlanCreateRequest</code></li>
+      <li><code>ForwardPlanResponse</code></li>
+      <li><code>ForwardPlanUpdateRequest</code></li>
+      <li><code>PermitRequest</code></li>
+      <li><code>PermitResponse</code></li>
+      <li><code>WorkCreateRequest</code></li>
+    </ol>
+  </li>
 </ol>
 
 Updated Reporting API with the following changes:


### PR DESCRIPTION
add note to version and changes documentation from sprint 3
to give forward notice that some optional fields are being added
to the PermitASD interface.

![Screenshot 2020-05-19 at 11 55 46](https://user-images.githubusercontent.com/32199652/82318397-b0aeaa80-99c7-11ea-8794-440e1a5d9d4b.png)
