### PR TITLE
Notify users of upcoming ISO 8601 datetime changes

### DIFF
--- a/docs/api-documentation/V1.24/index.md
+++ b/docs/api-documentation/V1.24/index.md
@@ -2712,6 +2712,12 @@ Street Manager is in public beta. This means it is still in active development a
 You can <a href="mailto:streetmanager@dft.gov.uk">contact us</a> for more detail about these features, or to suggest something else you’d like Street Manager to offer.
 {: .govuk-body}
 
+### Use the ISO 8601 standard for datetime values in hourly generated extracts
+{: .govuk-heading-s}
+
+Currently the hourly generated CSV files exposed through the Data Export API use localised date and time strings for datetime values. This will be updated to use the ISO 8601 notitation, in-line with the Works API responses, removing ambiguity regarding timezones. The target API version for this update is V1.25.
+{: .govuk-body}
+
 ### Reporting API enhancements for search and filtering
 {: .govuk-heading-s}
 

--- a/docs/api-documentation/V1.24/index.md
+++ b/docs/api-documentation/V1.24/index.md
@@ -2715,7 +2715,7 @@ You can <a href="mailto:streetmanager@dft.gov.uk">contact us</a> for more detail
 ### Use the ISO 8601 standard for datetime values in hourly generated extracts
 {: .govuk-heading-s}
 
-Currently the hourly generated CSV files exposed through the Data Export API use localised date and time strings for datetime values. This will be updated to use the ISO 8601 notitation, in-line with the Works API responses, removing ambiguity regarding timezones. The target API version for this update is V1.25.
+Currently, the hourly generated CSV files exposed through the Data Export API use localised date and time strings for datetime values. This will be updated to use the ISO 8601 notitation, in line with the Works API responses, removing ambiguity regarding timezones. The target API version for this update is V1.25.
 {: .govuk-body}
 
 ### Reporting API enhancements for search and filtering


### PR DESCRIPTION
The data-export-api will be updated to return datetime values in ISO 8601 format to remove confusion around timezones.