### PR TITLE
SM-6110: Update release dates for sprint 10 prod release

### DIFF
--- a/docs/api-documentation/index.html
+++ b/docs/api-documentation/index.html
@@ -50,38 +50,18 @@ This is the V1 baseline specification which describes all legally required API f
 
 
 <ul class="govuk-list govuk-list--bullet">
-  <li>Sandbox
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        <!-- Released to sandbox but not production -->
-        <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V2.3/">
-          Version 2.3 - Released on 20/08/2020.
-        </a>
-      </li>
-      <li>
-        <!-- Released to sandbox but not production -->
-        <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V1.25.3/">
-          Version 1.25.3 - Released on 20/08/2020.
-        </a>
-      </li>
-    </ul>
-  </li>
-  <li>Production
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        <!-- UPDATE ME to latest/current version -->
-        <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V2.2/">
-          Version 2.2 - Released on 13/08/2020.
-        </a>
-      </li>
-      <li>
-        <!-- UPDATE ME to latest/current stable version if required -->
-        <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V1.25.2/">
-          Version 1.25.2 - Released on 30/07/2020.
-        </a>
-      </li>
-    </ul>
-  </li>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>
+      <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V2.3/">
+        Version 2.3 - Released to Sandbox on 20/08/2020. Released to Production on 27/08/2020.
+      </a>
+    </li>
+    <li>
+      <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V1.25.3/">
+        Version 1.25.3 - Released to Sandbox on 20/08/2020. Released to Production on 27/08/2020.
+      </a>
+    </li>
+  </ul>
 </ul>
 
 <p class="govuk-body-m">
@@ -89,50 +69,20 @@ This is the V1 baseline specification which describes all legally required API f
 </p>
 
 <ul class="govuk-list govuk-list--bullet">
-  <li>Sandbox
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        <!-- UPDATE ME to upcoming latest version -->
-        <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V2.4/">
-          Version 2.4 - Due for release on 03/09/2020.
-        </a>
-      </li>
-      <!-- <li> -->
-        <!-- UPDATE ME to upcoming stable version if required -->
-        <!-- <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V1.25.4/">
-          Version 1.25.4 - Due for release on XX/XX/2020.
-        </a>
-      </li> -->
-    </ul>
-  </li>
-  <li>Production
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        <!-- UPDATE ME to upcoming latest version -->
-        <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V2.3/">
-          Version 2.3 - Due for release on 27/08/2020.
-        </a>
-      </li>
-      <li>
-        <!-- UPDATE ME to upcoming stable version if required -->
-        <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V1.25.3/">
-          Version 1.25.3 - Due for release on 27/08/2020.
-        </a>
-      </li>
-      <li>
-        <!-- UPDATE ME to upcoming latest version -->
-        <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V2.4/">
-          Version 2.4 - Due for release on 10/09/2020.
-        </a>
-      </li>
-      <!-- <li> -->
-        <!-- UPDATE ME to upcoming stable version if required -->
-        <!-- <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V1.25.4/">
-          Version 1.25.4 - Due for release on XX/XX/2020.
-        </a>
-      </li> -->
-    </ul>
-  </li>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>
+      <!-- UPDATE ME to upcoming latest version -->
+      <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V2.4/">
+        Version 2.4 - Due for release to Sandbox on 03/09/2020. Due for release to Production on 10/09/2020.
+      </a>
+    </li>
+    <!-- <li> -->
+      <!-- UPDATE ME to upcoming stable version if required -->
+      <!-- <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V1.25.4/">
+        Version 1.25.4 - Due for release on XX/XX/2020.
+      </a>
+    </li> -->
+  </ul>
 </ul>
 
 <p class="govuk-body-m">


### PR DESCRIPTION
Reverted to previous format now that sandbox and production are on the same version.

![Screen Shot 2020-08-27 at 15 11 23](https://user-images.githubusercontent.com/9826034/91453411-96faea00-e877-11ea-81d3-a4afe74d2a6f.png)
