### PR TITLE
SM-6845: correct v3 doc link on index page to uppercase

### DIFF
--- a/docs/api-documentation/index.html
+++ b/docs/api-documentation/index.html
@@ -74,7 +74,7 @@ This is the V2 baseline specification which describes all legally required API f
   <ul class="govuk-list govuk-list--bullet">
     <li>
       <!-- UPDATE ME to upcoming latest version -->
-      <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V3/v3.0/">
+      <a class="govuk-link" href="{{ site.baseurl }}/api-documentation/V3/V3.0/">
         Version 3.0 - Due for release to Sandbox on 29/04/2021. Due for release to Production on 04/05/2021.
       </a>
     </li>


### PR DESCRIPTION
Locally the `V3/v3.0` link worked but on GitHub pages it did not correct the case to `V3/V3.0` on the index page.
