### PR TITLE
hotfix/SM0000 Update service availability page for IE issue

### DIFF
--- a/docs/_articles/disruptions-to-service-availability.md
+++ b/docs/_articles/disruptions-to-service-availability.md
@@ -10,7 +10,7 @@ This page lists all known occurrences of Street Manager service being unavailabl
 
 ## Issue notification
 
-* We are aware of a blank screen when raising permits using Internet Explorer. As a workaround we advise users to use a different browser. We are investigating this issue as a matter of priority.
+We are aware of a blank screen when raising permits using Internet Explorer. As a workaround we advise users to use a different browser. We are investigating this issue as a matter of priority.
 
 ## April 2021
 

--- a/docs/_articles/disruptions-to-service-availability.md
+++ b/docs/_articles/disruptions-to-service-availability.md
@@ -8,6 +8,10 @@ status: publish
 ---
 This page lists all known occurrences of Street Manager service being unavailable.
 
+## Issue notification
+
+* We are aware of a blank screen when raising permits using Internet Explorer. As a workaround we advise users to use a different browser. We are investigating this issue as a matter of priority.
+
 ## April 2021
 
 **Production environment**


### PR DESCRIPTION
Adding notification of IE11 issue to top of service availability page - using:

"Issue Notification: We are aware of a blank screen when raising permits using Internet Explorer. As a workaround we advise users to use a different browser. We are investigating this issue as a matter of priority."