### PR TITLE
Update IE issue text on Service Availability page

### DIFF
--- a/docs/_articles/disruptions-to-service-availability.md
+++ b/docs/_articles/disruptions-to-service-availability.md
@@ -10,7 +10,7 @@ This page lists all known occurrences of Street Manager service being unavailabl
 
 ## Issue notification
 
-We are aware of a blank screen when raising permits using Internet Explorer. As a workaround we advise users to use a different browser. We are investigating this issue as a matter of priority.
+We are aware of a blank screen when performing some actions involving maps using Internet Explorer. We have identified a fix which will be included in the next release. In the meantime, we advise users to use a different browser. This issue only affects Internet Explorer.
 
 ## April 2021
 


### PR DESCRIPTION
Updating text on service availability page to following: 

We are aware of a blank screen when performing some actions involving maps using Internet Explorer. We have identified a fix which will be included in the next release. In the meantime, we advise users to use a different browser. This issue only affects Internet Explorer.

